### PR TITLE
Fix check on database existence in PLocalClient

### DIFF
--- a/src/main/scala/oriented/OrientClient.scala
+++ b/src/main/scala/oriented/OrientClient.scala
@@ -109,7 +109,7 @@ case class PLocalClient(uri: String, db: String, user: String, password: String,
 
   val serverAdmin: OServerAdmin = new OServerAdmin(uri).connect(user, password)
 
-  if(!serverAdmin.existsDatabase()) serverAdmin.createDatabase(db, "document", "plocal")
+  if(!serverAdmin.existsDatabase(db)) serverAdmin.createDatabase(db, "document", "plocal")
 
 }
 


### PR DESCRIPTION
Currently every time a `PLocalClient` is instantiated it tries to create the database which leads to a `com.orientechnologies.orient.core.exception.ODatabaseException` if the database already exists. Should be fixed by fixing the check on database existence by passing the correct database name to `OServerAdmin#existsDatabase`.
