### PR TITLE
Remove database creation in PLocalClient and include db in uri

### DIFF
--- a/src/main/scala/oriented/OrientClient.scala
+++ b/src/main/scala/oriented/OrientClient.scala
@@ -107,9 +107,7 @@ case class InMemoryClient(db: String, user: String = "root", password: String = 
   */
 case class PLocalClient(uri: String, db: String, user: String, password: String, pool: Option[(Int, Int)] = None) extends OrientClient {
 
-  val serverAdmin: OServerAdmin = new OServerAdmin(uri).connect(user, password)
-
-  if(!serverAdmin.existsDatabase(db)) serverAdmin.createDatabase(db, "document", "plocal")
+  val serverAdmin: OServerAdmin = new OServerAdmin(s"$uri/$db").connect(user, password)
 
 }
 


### PR DESCRIPTION
To do the database existential check, the storage type and database is required. This change proposes to take the check on database existence out of the `PLocalClient`, so the user of the library can do that. The database name is added to the constructor of `OServerAdmin` so the client is set up correctly for a database on a URI.